### PR TITLE
refactor(catalog): Capabilities and Generators are now classes

### DIFF
--- a/catalog/capabilities/database/index.ts
+++ b/catalog/capabilities/database/index.ts
@@ -1,8 +1,10 @@
 
-import * as DatabaseSecret from 'generators/database-secret';
-import * as DatabasePostgresql from 'generators/database-postgresql';
-import * as DatabaseMysql from 'generators/database-mysql';
-import * as DatabaseCrudVertx from 'generators/database-crud-vertx';
+import { BaseCapability } from 'core/catalog';
+
+import DatabaseSecret from 'generators/database-secret';
+import DatabasePostgresql from 'generators/database-postgresql';
+import DatabaseMysql from 'generators/database-mysql';
+import DatabaseCrudVertx from 'generators/database-crud-vertx';
 
 // Returns the corresponding database generator depending on the given database type
 function databaseByType(type) {
@@ -24,28 +26,26 @@ function runtimeByType(type) {
     }
 }
 
-export const id = 'database';
+export default class Database extends BaseCapability {
+    public static readonly sourceDir: string = __dirname;
 
-export async function apply(applyGenerator, resources, targetDir, props) {
-    const dbprops = {
-        'application': props.application,
-        'databaseUri': props.application + '-database',
-        'databaseName': 'my_data',
-        'secretName': props.application + '-database-bind',
-    };
-    const rtprops = {
-        'application': props.application,
-        'groupId': props.groupId,
-        'artifactId': props.artifactId,
-        'version': props.version,
-        'databaseType': props.databaseType,
-        'secretName': props.application + '-database-bind',
-    };
-    await applyGenerator(DatabaseSecret, resources, targetDir, dbprops);
-    await applyGenerator(databaseByType(props.databaseType), resources, targetDir, dbprops);
-    return await applyGenerator(runtimeByType(props.runtime), resources, targetDir, rtprops);
-}
-
-export function info() {
-    return require('./info.json');
+    public async apply(resources, props) {
+        const dbprops = {
+            'application': props.application,
+            'databaseUri': props.application + '-database',
+            'databaseName': 'my_data',
+            'secretName': props.application + '-database-bind',
+        };
+        const rtprops = {
+            'application': props.application,
+            'groupId': props.groupId,
+            'artifactId': props.artifactId,
+            'version': props.version,
+            'databaseType': props.databaseType,
+            'secretName': props.application + '-database-bind',
+        };
+        await this.applyGenerator(DatabaseSecret, resources, dbprops);
+        await this.applyGenerator(databaseByType(props.databaseType), resources, dbprops);
+        return await this.applyGenerator(runtimeByType(props.runtime), resources, rtprops);
+    }
 }

--- a/catalog/capabilities/rest/index.ts
+++ b/catalog/capabilities/rest/index.ts
@@ -1,5 +1,7 @@
 
-import * as RestVertx from 'generators/rest-vertx';
+import { BaseCapability } from 'core/catalog';
+
+import RestVertx from 'generators/rest-vertx';
 
 // Returns the corresponding runtime generator depending on the given runtime type
 function runtimeByType(type) {
@@ -10,18 +12,16 @@ function runtimeByType(type) {
     }
 }
 
-export const id = 'rest';
+export default class Rest extends BaseCapability {
+    public static readonly sourceDir: string = __dirname;
 
-export async function apply(applyGenerator, resources, targetDir, props) {
-    const rtprops = {
-        'application': props.application,
-        'groupId': props.groupId,
-        'artifactId': props.artifactId,
-        'version': props.version
-    };
-    return await applyGenerator(runtimeByType(props.runtime), resources, targetDir, rtprops);
-}
-
-export function info() {
-    return require('./info.json');
+    public async apply(resources, props) {
+        const rtprops = {
+            'application': props.application,
+            'groupId': props.groupId,
+            'artifactId': props.artifactId,
+            'version': props.version
+        };
+        return await this.applyGenerator(runtimeByType(props.runtime), resources, rtprops);
+    }
 }

--- a/catalog/generators/database-crud-vertx/index.ts
+++ b/catalog/generators/database-crud-vertx/index.ts
@@ -1,48 +1,43 @@
 
-import { copy } from 'fs-extra';
-import { join } from 'path';
-import { mergePoms } from 'core/maven';
-import { transformFiles } from 'core/template';
 import { cases } from 'core/template/transformers';
-import { setDeploymentEnv } from 'core/resources';
+import { Resources, setDeploymentEnv } from 'core/resources';
+import { BaseGenerator } from 'core/catalog';
 
-import * as PlatformVertx from 'generators/platform-vertx';
+import PlatformVertx from 'generators/platform-vertx';
 
-export const id = 'database-crud-vertx';
+export default class DatabaseCrudVertx extends BaseGenerator {
+    public static readonly sourceDir: string = __dirname;
 
-export async function apply(applyGenerator, resources, targetDir, props: any = {}) {
-    const pprops = {
-        'application': props.application,
-        'groupId': props.groupId,
-        'artifactId': props.artifactId,
-        'version': props.version
-    };
-    const env = {
-        'MY_DATABASE_SERVICE_HOST': {
-            'secret': props.secretName,
-            'key': 'uri'
-        },
-        'DB_USERNAME': {
-            'secret': props.secretName,
-            'key': 'user'
-        },
-        'DB_PASSWORD': {
-            'secret': props.secretName,
-            'key': 'password'
-        }
-    };
-    // First copy the files from the base Vert.x platform module
-    // and then copy our own over that
-    await applyGenerator(PlatformVertx, resources, targetDir, pprops);
-    setDeploymentEnv(resources, env);
-    await copy(join(__dirname, 'files'), targetDir);
-    await mergePoms(join(targetDir, 'pom.xml'), join(__dirname, 'merge', `pom.${props.databaseType}.xml`));
-    await transformFiles(join(targetDir, 'src/**/*.java'), cases(props));
-    return resources;
-    // TODO Don't just blindly copy all files, we need to _patch_ some of
-    // them instead (eg. pom.xml and arquillian.xml and Java code)
-}
-
-export function info() {
-    return require('./info.json');
+    public async apply(resources: Resources, props?: any): Promise<Resources> {
+        const pprops = {
+            'application': props.application,
+            'groupId': props.groupId,
+            'artifactId': props.artifactId,
+            'version': props.version
+        };
+        const env = {
+            'MY_DATABASE_SERVICE_HOST': {
+                'secret': props.secretName,
+                'key': 'uri'
+            },
+            'DB_USERNAME': {
+                'secret': props.secretName,
+                'key': 'user'
+            },
+            'DB_PASSWORD': {
+                'secret': props.secretName,
+                'key': 'password'
+            }
+        };
+        // First copy the files from the base Vert.x platform module
+        // and then copy our own over that
+        await this.applyGenerator(PlatformVertx, resources, pprops);
+        setDeploymentEnv(resources, env);
+        await this.copy();
+        await this.mergePoms(`merge/pom.${props.databaseType}.xml`);
+        await this.transform('src/**/*.java', cases(props));
+        return resources;
+        // TODO Don't just blindly copy all files, we need to _patch_ some of
+        // them instead (eg. pom.xml and arquillian.xml and Java code)
+    }
 }

--- a/catalog/generators/database-mysql/index.ts
+++ b/catalog/generators/database-mysql/index.ts
@@ -1,17 +1,16 @@
 
 import { newDatabaseUsingSecret } from 'core/resources';
+import { BaseGenerator } from 'core/catalog';
 
-export const id = 'database-mysql';
+export default class DatabaseMysql extends BaseGenerator {
+    public static readonly sourceDir: string = __dirname;
 
-export async function apply(applyGenerator, resources, targetDir, props: any = {}) {
-    return await newDatabaseUsingSecret(resources, props.application, 'mysql', {
-        'MYSQL_ROOT_PASSWORD': 'verysecretrootpassword',
-        'MYSQL_DATABASE': { 'secret': props.secretName, 'key': 'database' },
-        'MYSQL_USER': { 'secret': props.secretName, 'key': 'user'},
-        'MYSQL_PASSWORD': { 'secret': props.secretName, 'key': 'password'}
-    });
-}
-
-export function info() {
-    return require('./info.json');
+    public async apply(resources, props: any = {}) {
+        return await newDatabaseUsingSecret(resources, props.application, 'mysql', {
+            'MYSQL_ROOT_PASSWORD': 'verysecretrootpassword',
+            'MYSQL_DATABASE': { 'secret': props.secretName, 'key': 'database' },
+            'MYSQL_USER': { 'secret': props.secretName, 'key': 'user'},
+            'MYSQL_PASSWORD': { 'secret': props.secretName, 'key': 'password'}
+        });
+    }
 }

--- a/catalog/generators/database-postgresql/index.ts
+++ b/catalog/generators/database-postgresql/index.ts
@@ -1,16 +1,15 @@
 
 import { newDatabaseUsingSecret } from 'core/resources';
+import { BaseGenerator } from 'core/catalog';
 
-export const id = 'database-postgresql';
+export default class DatabasePostgresql extends BaseGenerator {
+    public static readonly sourceDir: string = __dirname;
 
-export async function apply(applyGenerator, resources, targetDir, props: any = {}) {
-    return await newDatabaseUsingSecret(resources, props.application, 'postgresql', {
-        'POSTGRESQL_DATABASE': {'secret': props.secretName, 'key': 'database'},
-        'POSTGRESQL_USER': {'secret': props.secretName, 'key': 'user'},
-        'POSTGRESQL_PASSWORD': {'secret': props.secretName, 'key': 'password'}
-    });
-}
-
-export function info() {
-    return require('./info.json');
+    public async apply( resources, props: any = {}) {
+        return await newDatabaseUsingSecret(resources, props.application, 'postgresql', {
+            'POSTGRESQL_DATABASE': { 'secret': props.secretName, 'key': 'database' },
+            'POSTGRESQL_USER': { 'secret': props.secretName, 'key': 'user' },
+            'POSTGRESQL_PASSWORD': { 'secret': props.secretName, 'key': 'password' }
+        });
+    }
 }

--- a/catalog/generators/database-secret/index.ts
+++ b/catalog/generators/database-secret/index.ts
@@ -1,33 +1,33 @@
 
-export const id = 'database-secret';
+import { BaseGenerator } from 'core/catalog';
 
-export async function apply(applyGenerator, resources, targetDir, props: any = {}) {
-    // Create Secret holding Database connection/authentication information
-    if (!resources.secret(props.secretName)) {
-        const secret = {
-            'kind': 'Secret',
-            'apiVersion': 'v1',
-            'metadata': {
-                'name': props.secretName,
-                'labels': {
-                    'app': props.application,
+export default class DatabaseSecret extends BaseGenerator {
+    public static readonly sourceDir: string = __dirname;
+
+    public async apply(resources, props: any = {}) {
+        // Create Secret holding Database connection/authentication information
+        if (!resources.secret(props.secretName)) {
+            const secret = {
+                'kind': 'Secret',
+                'apiVersion': 'v1',
+                'metadata': {
+                    'name': props.secretName,
+                    'labels': {
+                        'app': props.application,
+                    }
+                },
+                'stringData': {
+                    'uri': props.databaseUri,
+                    'database': props.databaseName,
+                    'user': 'dbuser',
+                    'password': 'secret',  // TODO generate pwd
                 }
-            },
-            'stringData': {
-                'uri': props.databaseUri,
-                'database': props.databaseName,
-                'user': 'dbuser',
-                'password': 'secret',  // TODO generate pwd
-            }
-        };
-        resources.add(secret);
-        // console.log(`Secret ${props.secretName} added`);
-    } else {
-        // console.log(`Secret ${props.secretName} already exists`);
+            };
+            resources.add(secret);
+            // console.log(`Secret ${props.secretName} added`);
+        } else {
+            // console.log(`Secret ${props.secretName} already exists`);
+        }
+        return resources;
     }
-    return resources;
-}
-
-export function info() {
-    return require('./info.json');
 }

--- a/catalog/generators/maven-setup/index.ts
+++ b/catalog/generators/maven-setup/index.ts
@@ -1,13 +1,10 @@
 
-import { join } from 'path';
-import { updateGav } from 'core/maven';
+import { BaseGenerator } from 'core/catalog';
 
-export const id = 'maven-setup';
+export default class MavenSetup extends BaseGenerator {
+    public static readonly sourceDir: string = __dirname;
 
-export async function apply(applyGenerator, resources, targetDir, props: any = {}) {
-    return await updateGav(join(targetDir, 'pom.xml'), props.groupId, props.artifactId, props.version);
-}
-
-export function info() {
-    return require('./info.json');
+    public async apply(resources, props: any = {}) {
+        return await this.updateGav(props.groupId, props.artifactId, props.version);
+    }
 }

--- a/catalog/generators/platform-vertx/index.ts
+++ b/catalog/generators/platform-vertx/index.ts
@@ -1,35 +1,31 @@
 
-import { copy } from 'fs-extra' ;
-import { join } from 'path';
 import { newApp, newRoute } from 'core/resources';
-import { transformFiles } from 'core/template';
 import { cases } from 'core/template/transformers';
+import { BaseGenerator } from 'core/catalog';
 
-import * as WelcomeApp from 'generators/welcome-app';
-import * as MavenSetup from 'generators/maven-setup';
+import WelcomeApp from 'generators/welcome-app';
+import MavenSetup from 'generators/maven-setup';
 
-export const id = 'platform-vertx';
+export default class PlatformVertx extends BaseGenerator {
+    public static readonly sourceDir: string = __dirname;
 
-export async function apply(applyGenerator, resources, targetDir, props: any = {}) {
-    const serviceName = props.application + '-vertx';
-    const tprops = {
-        ...props,
-        'serviceName': serviceName
-    };
-    await copy(join(__dirname, 'files'), targetDir);
-    await transformFiles(join(targetDir, 'gap'), cases(tprops));
-    await applyGenerator(WelcomeApp, resources, targetDir, props);
-    await applyGenerator(MavenSetup, resources, targetDir, props);
-    const res = await newApp(
+    public async apply(resources, props: any = {}) {
+        const serviceName = props.application + '-vertx';
+        const tprops = {
+            ...props,
+            'serviceName': serviceName
+        };
+        await this.copy();
+        await this.transform('gap', cases(tprops));
+        await this.applyGenerator(WelcomeApp, resources, props);
+        await this.applyGenerator(MavenSetup, resources, props);
+        const res = await newApp(
             serviceName,
             props.application,
             'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift',
             null,
             props.env || {});
-    resources.add(res);
-    return await newRoute(resources, props.application + '-route', props.application, serviceName);
-}
-
-export function info() {
-    return require('./info.json');
+        resources.add(res);
+        return await newRoute(resources, props.application + '-route', props.application, serviceName);
+    }
 }

--- a/catalog/generators/rest-vertx/index.ts
+++ b/catalog/generators/rest-vertx/index.ts
@@ -1,29 +1,25 @@
 
-import { copy } from 'fs-extra';
-import { join } from 'path';
-import { mergePoms } from 'core/maven';
+import { BaseGenerator } from 'core/catalog';
 
-import * as PlatformVertx from 'generators/platform-vertx';
+import PlatformVertx from 'generators/platform-vertx';
 
-export const id = 'rest-vertx';
+export default class RestVertx extends BaseGenerator {
+    public static readonly sourceDir: string = __dirname;
 
-export async function apply(applyGenerator, resources, targetDir, props: any = {}) {
-    // First copy the files from the base Vert.x platform module
-    // and then copy our own over that
-    const pprops = {
-        'application': props.application,
-        'groupId': props.groupId,
-        'artifactId': props.artifactId,
-        'version': props.version,
-    };
-    await applyGenerator(PlatformVertx, resources, targetDir, pprops);
-    await copy(join(__dirname, 'files'), targetDir);
-    await mergePoms(join(targetDir, 'pom.xml'), join(__dirname, 'merge', 'pom.xml'));
-    return resources;
-    // TODO Don't just blindly copy all files, we need to _patch_ some of
-    // them instead (eg. pom.xml and arquillian.xml and Java code)
-}
-
-export function info() {
-    return require('./info.json');
+    public async apply(resources, props: any = {}) {
+        // First copy the files from the base Vert.x platform module
+        // and then copy our own over that
+        const pprops = {
+            'application': props.application,
+            'groupId': props.groupId,
+            'artifactId': props.artifactId,
+            'version': props.version,
+        };
+        await this.applyGenerator(PlatformVertx, resources, pprops);
+        await this.copy();
+        await this.mergePoms();
+        return resources;
+        // TODO Don't just blindly copy all files, we need to _patch_ some of
+        // them instead (eg. pom.xml and arquillian.xml and Java code)
+    }
 }

--- a/catalog/generators/welcome-app/index.ts
+++ b/catalog/generators/welcome-app/index.ts
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 
 import { newApp, newRoute } from 'core/resources';
 import { writeResources } from 'core/deploy';
+import { BaseGenerator } from 'core/catalog';
 
 const WELCOME_APP_REPO_URL = 'https://github.com/fabric8-launcher/launcher-creator-welcome-app';
 
@@ -14,33 +15,31 @@ const buildTriggers = [{
     'imageChange': {}
 }];
 
-export const id = 'welcome-app';
+export default class WelcomeApp extends BaseGenerator {
+    public static readonly sourceDir: string = __dirname;
 
-export async function apply(applyGenerator, resources, targetDir, props: any = {}) {
-    const fileName = join(targetDir, '.openshiftio', 'service.welcome.yaml');
-    const serviceName = props.application + '-welcome';
-    const lbls = {
-        'app': props.application,
-        'apptype': 'welcome'
-    };
-    const res = await newApp(
-        serviceName,
-        lbls,
-        'bucharestgold/centos7-s2i-web-app',
-        WELCOME_APP_REPO_URL,
-        {});
-    const bc = res.buildConfig(serviceName);
-    // Set the Git repo URL to use the template parameter
-    _.set(bc, 'spec.source.git.uri', WELCOME_APP_REPO_URL);
-    // Remove GitHub webhook triggers
-    _.set(bc, 'spec.triggers', buildTriggers);
-    // Remove parameters
-    res.json.parameters = [];
-    // Adding Route
-    await newRoute(res, props.application + '-welcome-route', lbls, serviceName);
-    return await writeResources(fileName, res);
-}
-
-export function info() {
-    return require('./info.json');
+    public async apply(resources, props: any = {}) {
+        const fileName = join(this.targetDir, '.openshiftio', 'service.welcome.yaml');
+        const serviceName = props.application + '-welcome';
+        const lbls = {
+            'app': props.application,
+            'apptype': 'welcome'
+        };
+        const res = await newApp(
+            serviceName,
+            lbls,
+            'bucharestgold/centos7-s2i-web-app',
+            WELCOME_APP_REPO_URL,
+            {});
+        const bc = res.buildConfig(serviceName);
+        // Set the Git repo URL to use the template parameter
+        _.set(bc, 'spec.source.git.uri', WELCOME_APP_REPO_URL);
+        // Remove GitHub webhook triggers
+        _.set(bc, 'spec.triggers', buildTriggers);
+        // Remove parameters
+        res.json.parameters = [];
+        // Adding Route
+        await newRoute(res, props.application + '-welcome-route', lbls, serviceName);
+        return await writeResources(fileName, res);
+    }
 }

--- a/lib/core/catalog/index.ts
+++ b/lib/core/catalog/index.ts
@@ -1,38 +1,108 @@
 
-import { readdir, statSync } from 'fs-extra';
+import { readdir, statSync, copy } from 'fs-extra';
+import { join } from 'path';
 
-export function getCapabilityModule(capability) {
-    return require('../../../catalog/capabilities/' + capability);
+import { Resources } from 'core/resources';
+import { transformFiles } from 'core/template';
+import { mergePoms, updateGav } from 'core/maven';
+
+interface CatalogItem {
+    readonly sourceDir: string;
+    apply(resources: Resources, props?: any): Promise<Resources>;
 }
 
-export async function listCapabilities() {
+type applyFunc = (genConst: any, resources: Resources, props?: any) => Resources;
+
+abstract class BaseCatalogItem implements CatalogItem {
+    private readonly _sourceDir;
+
+    constructor(public readonly applyGenerator: applyFunc, public readonly targetDir) {
+        this._sourceDir = this.constructor['sourceDir'];
+        if (!this._sourceDir) {
+            throw new Error(`Class ${this.constructor.name} is missing static field "sourceDir"!`);
+        }
+    }
+
+    public get sourceDir(): string {
+        return this._sourceDir;
+    }
+
+    public abstract async apply(resources: Resources, props?: any): Promise<Resources>;
+
+    protected copy(from: string = 'files', to?: string): Promise<void> {
+        const from2 = join(this.sourceDir, from);
+        const to2 = !!to ? join(this.targetDir, to) : this.targetDir;
+        return copy(from2, to2);
+    }
+
+    protected transform(pattern: string | string[], transformLine: (line: string) => string): Promise<number> {
+        let pattern2;
+        if (typeof pattern === 'string') {
+            pattern2 = join(this.targetDir, pattern);
+        } else {
+            // TODO fix array elements too
+            pattern2 = pattern;
+        }
+        return transformFiles(pattern2, transformLine);
+    }
+
+    protected updateGav(groupId, artifactId, version, pomFile = 'pom.xml') {
+        return updateGav(join(this.targetDir, 'pom.xml'), groupId, artifactId, version);
+    }
+
+    protected mergePoms(sourcePom = 'merge/pom.xml', targetPom = 'pom.xml') {
+        return mergePoms(join(this.targetDir, targetPom), join(this.sourceDir, sourcePom));
+    }
+}
+
+export function info(itemConst) {
+    return require(join(itemConst.sourceDir, 'info.json'));
+}
+
+interface Capability extends CatalogItem {
+}
+
+interface Generator extends CatalogItem {
+}
+
+export abstract class BaseGenerator extends BaseCatalogItem implements Generator {
+}
+
+export abstract class BaseCapability extends BaseCatalogItem implements Capability {
+}
+
+export function getCapabilityModule(capability) {
+    return require('../../../catalog/capabilities/' + capability).default;
+}
+
+async function listCapabilities() {
     const files = await readdir('./catalog/capabilities');
     return files
         .filter(f => statSync('./catalog/capabilities/' + f).isDirectory())
-        .map(f => getCapabilityModule(f));
+        .map(f => [f, getCapabilityModule(f)]);
 }
 
 export async function listCapabilityInfos() {
     const caps = await listCapabilities();
     return caps
-        .map(c => ({ 'module': c.id, ...c.info() }));
+        .map(([f, c]) => ({ 'module': f, ...info(c) }));
 }
 
 export function getGeneratorModule(generator) {
-    return require('../../../catalog/generators/' + generator);
+    return require('../../../catalog/generators/' + generator).default;
 }
 
-export async function listGenerators() {
+async function listGenerators() {
     const files = await readdir('./catalog/generators');
     return files
         .filter(f => statSync('./catalog/generators/' + f).isDirectory())
-        .map(f => getGeneratorModule(f));
+        .map(f => [f, getGeneratorModule(f)]);
 }
 
 export async function listGeneratorInfos() {
     const gens = await listGenerators();
     return gens
-        .map(g => ({'module': g.id, ...g.info()}));
+        .map(([f, g]) => ({'module': f, ...info(g)}));
 }
 
 export function listRuntimes(generator?: any) {

--- a/lib/core/deploy/apply.ts
+++ b/lib/core/deploy/apply.ts
@@ -1,6 +1,6 @@
 
 import { printUsage } from 'core/info';
-import { listCapabilityInfos, getCapabilityModule } from 'core/catalog';
+import { listCapabilityInfos, getCapabilityModule, info } from 'core/catalog';
 import { resources } from 'core/resources';
 import { apply } from '.';
 
@@ -16,7 +16,7 @@ if (args.length === 1 && args[0] === '--list') {
     console.log(`    app_name        - The name of the application.`);
     console.log(`    ${CAP.padEnd(15)} - The name of the Capability to apply.`);
     console.log(`    json_props      - These will be passed to the Capability:`);
-    printUsage(getCapabilityModule(CAP).info().props);
+    printUsage(info(getCapabilityModule(CAP)).props);
     process.exit(0);
 } else if (args.length < 4) {
     console.error(`Missing arguments`);

--- a/test/catalog/catalog.test.ts
+++ b/test/catalog/catalog.test.ts
@@ -11,7 +11,7 @@ test('catalog list capabilities', (t) => {
 test('catalog get capability', (t) => {
     t.plan(1);
 
-    t.is(catalog.getCapabilityModule('database').info().type, 'capability');
+    t.is(catalog.info(catalog.getCapabilityModule('database')).type, 'capability');
 });
 
 test('catalog list generators', (t) => {
@@ -23,5 +23,5 @@ test('catalog list generators', (t) => {
 test('catalog get generator', (t) => {
     t.plan(1);
 
-    t.is(catalog.getGeneratorModule('platform-vertx').info().type, 'generator');
+    t.is(catalog.info(catalog.getGeneratorModule('platform-vertx')).type, 'generator');
 });


### PR DESCRIPTION
Hey guys, could you take a look at this and let me know what you think? Use this link to see the diff, it makes things clearer: https://github.com/fabric8-launcher/launcher-creator-backend/compare/catalog_classes?expand=1&w=1

So the idea was to make implementing the Capabilities and Generators as easy as possible for others (the runtime teams). So instead of just having a simple module with an `apply()` function there's now a class that you need to create:

```
export default class Rest extends BaseCapability {
    public async apply(resources, props) {
        // Your code here
    }

    public readonly sourceDir: string = __dirname;

    public static info() { return require('./info.json'); }
}
```

This of course introduces some complexity. But it allows us to give the user access to some methods from the base class that should make the default actions easier to implement. See for example the difference between:

    copy(join(__dirname, 'files'), targetDir);

and:

    this.copy();

By default , the `copy()` method assumes that the source folder is the Generator's own folder and that the target folder is the folder where the project get's created. If you say:

    this.copy('some/files');

It will assume the `some/files` is relative to the Generator's source folder, etc.

So my question to you is? "Is it worth it?". Is it worth the slightly added complexity of having to make a class so we can make life easier for the outside devs?
