### PR TITLE
chore(openshift): Added ENV vars for Welcome App

### DIFF
--- a/catalog/generators/welcome-app/index.ts
+++ b/catalog/generators/welcome-app/index.ts
@@ -53,6 +53,7 @@ export default class WelcomeApp extends BaseGenerator {
 
         res.parameter('FRONTEND_SERVICE_NAME')['value'] = !props.tier ? props.application : this.name(props.application, 'frontend');
         res.parameter('BACKEND_SERVICE_NAME')['value'] = !props.tier ? props.application : this.name(props.application, 'backend');
+        res.parameter('WELCOME_IMAGE_NAME')['value'] = process.env['WELCOME_IMAGE_NAME'] || 'fabric8/launcher-creator-welcome-app';
         res.parameter('WELCOME_IMAGE_TAG')['value'] = process.env['WELCOME_IMAGE_TAG'] || 'latest';
         res.parameter('WELCOME_APP_CONFIG')['value'] = JSON.stringify(props.deployment.applications[0]);
 

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -15,6 +15,18 @@ message: "The following service has been created in your project: launcher-creat
 labels:
   template: launcher-creator-backend
 parameters:
+- name: WELCOME_IMAGE_NAME
+  description: The Welcome App's image name
+  displayName: Image Name
+  required: true
+  value: fabric8/launcher-creator-welcome-app
+
+- name: WELCOME_IMAGE_TAG
+  description: The Welcome App's image tag
+  displayName: Image Tag
+  required: true
+  value: latest
+  
 - name: IMAGE
   value: fabric8/launcher-creator-backend
   required: true
@@ -88,6 +100,10 @@ objects:
           env:
           - name: LAUNCHER_BACKEND_URL
             value: http://launcher-backend:8080/api
+          - name: WELCOME_IMAGE_NAME
+            value: ${WELCOME_IMAGE_NAME}
+          - name: WELCOME_IMAGE_TAG
+            value: ${WELCOME_IMAGE_TAG}
           - name: SENTRY_DSN
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
The OpenShift template for the creator backend itself now has parameters for setting the Welcome App's image name and tag to use when generating projects