### PR TITLE
WIP - Fix argument processing in tests

### DIFF
--- a/it-test/functions.ts
+++ b/it-test/functions.ts
@@ -70,7 +70,7 @@ export function getServiceName(part: Part) {
 }
 
 function procArgs() {
-    return _.takeRightWhile(process.argv, i => i.startsWith('--'));
+    return _.filter(process.argv, i => i.startsWith('--'));
 }
 
 export function isDryRun() {


### PR DESCRIPTION
[`_.takeRightWhile`](https://lodash.com/docs/#takeRightWhile) stops as soon as the predicate fails. We don't want that. We want to take all options, no matter what.

Please note that no runtime called `dotnet` exists when I run the commands:

# Before:

```
$ yarn ittest --runtimes=dotnet --verbose --timeout 1000000 | tee omajid-test.l og                                                                                                                   
yarn run v1.13.0                                                                                                     
$ NODE_PATH=lib:catalog mocha --opts it-test/mocha.opts -r ts-node/register it-test/all-tests.ts --runtimes=dotnet --v
erbose --timeout 1000000                                                                                             
                                                        
                                                                      
  Backends                                                  
    Runtime nodejs with database,health,rest,welcome       
```

# After:

```
$ yarn ittest --runtimes=dotnet --verbose --timeout 1000000 | tee omajid-test.log                                                                                                                   
yarn run v1.13.0                                                                                                     
$ NODE_PATH=lib:catalog mocha --opts it-test/mocha.opts -r ts-node/register it-test/all-tests.ts --runtimes=dotnet --v
erbose --timeout 1000000                                                                                             
                                                        
                                                                      
  0 passing (2ms)                                                                                                     
                                                                    
Done in 1.70s.                         
```

cc @gastaldi 