### PR TITLE
test: install dotnet commands in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,15 @@ jobs:
             export PATH=/usr/local/maven/apache-maven-3.6.0/bin:${PATH}
             mvn --version
       - run:
+          name: Install .NET Core 2.2
+          command: |
+            sudo apt-get update && sudo apt-get install -y dpkg
+            curl -sSO https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
+            sudo dpkg -i packages-microsoft-prod.deb
+            sudo apt-get install -y apt-transport-https
+            sudo apt-get update && sudo apt-get install -y dotnet-sdk-2.2
+            dotnet --info
+      - run:
           name: Install node@v10.10.0
           command: |
             export NVM_DIR="/opt/circleci/.nvm"


### PR DESCRIPTION
Add .NET Core 2.2 to CI setup. Hopefully that lets us test .NET Core support in our CI setup.

dpkg needs to be upgraded to add support for .xz inside .deb archives. This is what .NET Core uses. See https://github.com/dotnet/core/issues/2381 for more details.
