### PR TITLE
WIP: chore(generators): Use the correct compatiblity level for dotnet

### DIFF
--- a/catalog/generators/platform-dotnet/files/Startup.cs
+++ b/catalog/generators/platform-dotnet/files/Startup.cs
@@ -30,7 +30,7 @@ namespace {{.dotnet.namespace}}
 
             services.AddHealthChecks();
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
The compatibility level should be set to the latest version unless there's a real need for backwards compatibility.