### PR TITLE
Update the link for .NET Core

### DIFF
--- a/lib/core/catalog/enums.json
+++ b/lib/core/catalog/enums.json
@@ -8,7 +8,7 @@
       "metadata": {
         "categories": [ "backend" ],
         "language": "csharp",
-        "website": "https://dotnet.microsoft.com/apps/aspnet"
+        "website": "https://docs.microsoft.com/en-us/dotnet/core"
       }
     },
     {


### PR DESCRIPTION
Currently https://launch.prod-preview.openshift.io/launch/login links to https://dotnet.microsoft.com/apps/aspnet. I got some feedback that this may not be the best location.

Some options for other locations:

- https://github.com/dotnet/core
  - This is the github home page for .NET Core
- https://dotnetfoundation.org/Projects?searchquery=.NET+Core&type=project 
  - Unfortunately, .NET Foundation doesn't have a page for .NET Core as project. It shows up in search results but links to other locations
- https://docs.microsoft.com/en-ca/dotnet/
   - This is just documentation, not a landing page, as such.

Anyone have other ideas about what we could link to?

cc @Bob-Davis @tmds @dbhole @aslicerh @RheaAyase